### PR TITLE
ERB Syntax Error in sinatra/example

### DIFF
--- a/sinatra/views/layout.erb
+++ b/sinatra/views/layout.erb
@@ -4,6 +4,6 @@
   <title>PAY.JP Sinatra Example</title>
   </head>
 <body>
-  <%== yield %>
+  <%= yield %>
 </body>
 </html>


### PR DESCRIPTION
```
erb -x -T '-' views/* | ruby -c
-:15: syntax error, unexpected '='
; _erbout.concat((= yield ).to_s); _erbout.concat "\n"
```

😰

```
erb -x -T '-' views/* | ruby -c
Syntax OK
```

👍
